### PR TITLE
fixed: inverter = 0 causes unexpected pinstate value

### DIFF
--- a/Rotary.cpp
+++ b/Rotary.cpp
@@ -94,7 +94,7 @@ void Rotary::begin(bool internalPullup, bool flipLogicForPulldown) {
 
 unsigned char Rotary::process() {
   // Grab state of input pins.
-  unsigned char pinstate = ((inverter - digitalRead(pin2)) << 1) | (inverter - digitalRead(pin1));
+  unsigned char pinstate = ((inverter ^ digitalRead(pin2)) << 1) | (inverter ^ digitalRead(pin1));
   // Determine new state from the pins and state table.
   state = ttable[state & 0xf][pinstate];
   // Return emit bits, ie the generated event.


### PR DESCRIPTION
I am using pull-up circuit with your library and it does not work well.
This is because the code has `inverter - digitalRead(...)` and it will be `255` instead of `0` if the return value of `digitalRead(...)` is `1`. 
`inverter ^ digitalRead(...)` should return expected inverted value.