### PR TITLE
Adding inline get methods to access encoder pins.

### DIFF
--- a/Rotary.h
+++ b/Rotary.h
@@ -24,6 +24,9 @@ class Rotary
     Rotary(char, char);
     unsigned char process();
     void begin(bool internalPullup=true, bool flipLogicForPulldown=false);
+  
+    inline unsigned char pin_1() const { return pin1; }
+    inline unsigned char pin_2() const { return pin2; }
   private:
     unsigned char state;
     unsigned char pin1;


### PR DESCRIPTION
Allows for read-only retrieval of the encoder's A/B pins after construction.